### PR TITLE
add gnuplot compiler plugin

### DIFF
--- a/compiler/gnuplot.vim
+++ b/compiler/gnuplot.vim
@@ -1,0 +1,27 @@
+" Vim compiler file
+" Language:		Gnuplot
+" ----------------------------------------------------------------------------
+
+if exists("current_compiler")
+  finish
+endif
+let current_compiler = "gnuplot"
+
+if exists(":CompilerSet") != 2		" older Vim always used :setlocal
+  command -nargs=* CompilerSet setlocal <args>
+endif
+
+let s:cpo_save = &cpo
+set cpo-=C
+
+CompilerSet makeprg=gnuplot\ %
+
+CompilerSet errorformat=
+      \%E%p^,
+      \%Z\"%f\"\\,\ line\ %l:\ %m,
+      \%-G%.%#
+
+let &cpo = s:cpo_save
+unlet s:cpo_save
+
+" vim: nowrap sw=2 sts=2 ts=8:

--- a/ftplugin/gnuplot.vim
+++ b/ftplugin/gnuplot.vim
@@ -5,3 +5,5 @@ setlocal shiftwidth=4
 
 setlocal commentstring=#\ %s
 setlocal completefunc=syntaxcomplete#Complete
+
+compiler gnuplot


### PR DESCRIPTION
`:make` runs the file through gnuplot, and parses the error for `:copen`